### PR TITLE
Color-code cash discrepancies

### DIFF
--- a/components/DailyOperations.tsx
+++ b/components/DailyOperations.tsx
@@ -388,9 +388,14 @@ export function DailyOperations({ location, user }: DailyOperationsProps) {
                   </div>
                   <div className="flex justify-between items-center py-2">
                     <span className="font-medium">Diferencia:</span>
-                    <Badge 
-                      variant={getCashDifference() === 0 ? 'default' : 'destructive'}
-                      className="text-base py-2 px-3"
+                    <Badge
+                      className={`text-base py-2 px-3 text-white ${
+                        getCashDifference() > 0
+                          ? 'bg-green-500'
+                          : getCashDifference() < 0
+                          ? 'bg-red-500'
+                          : 'bg-blue-500'
+                      }`}
                     >
                       {getCashDifference().toFixed(2)}€
                     </Badge>
@@ -411,9 +416,14 @@ export function DailyOperations({ location, user }: DailyOperationsProps) {
                   </div>
                   <div className="flex justify-between items-center py-2">
                     <span className="font-medium">Diferencia:</span>
-                    <Badge 
-                      variant={getCardDifference() === 0 ? 'default' : 'destructive'}
-                      className="text-base py-2 px-3"
+                    <Badge
+                      className={`text-base py-2 px-3 text-white ${
+                        getCardDifference() > 0
+                          ? 'bg-green-500'
+                          : getCardDifference() < 0
+                          ? 'bg-red-500'
+                          : 'bg-blue-500'
+                      }`}
                     >
                       {getCardDifference().toFixed(2)}€
                     </Badge>

--- a/components/RecordsHistory.tsx
+++ b/components/RecordsHistory.tsx
@@ -114,10 +114,26 @@ function RecordRow({
       <TableCell>{record.user}</TableCell>
       <TableCell>{record.cashSales.toFixed(2)}€</TableCell>
       <TableCell>{record.cardSales.toFixed(2)}€</TableCell>
-      <TableCell className={cashDiff === 0 ? 'text-green-600' : 'text-red-600'}>
+      <TableCell
+        className={
+          cashDiff > 0
+            ? 'text-green-600'
+            : cashDiff < 0
+            ? 'text-red-600'
+            : 'text-blue-600'
+        }
+      >
         {cashDiff !== null ? `${cashDiff.toFixed(2)}€` : 'Calculando...'}
       </TableCell>
-      <TableCell className={cardDiff === 0 ? 'text-green-600' : 'text-red-600'}>
+      <TableCell
+        className={
+          cardDiff > 0
+            ? 'text-green-600'
+            : cardDiff < 0
+            ? 'text-red-600'
+            : 'text-blue-600'
+        }
+      >
         {cardDiff.toFixed(2)}€
       </TableCell>
       <TableCell>


### PR DESCRIPTION
## Summary
- color-code cash and card differences in daily summary and records history
- highlight positive values in green, negatives in red, and balanced results in blue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6a04567a08329b89e53c04da0664c